### PR TITLE
Cast objc_msgSend calls to placate compiler.

### DIFF
--- a/PSMenuItem.m
+++ b/PSMenuItem.m
@@ -102,7 +102,7 @@ BOOL PSPDFPIsMenuItemSelector(SEL selector) {
                     if (PSPDFPIsMenuItemSelector(selector)) {
                         return [NSMethodSignature signatureWithObjCTypes:"v@:@"]; // fake it.
                     }else {
-                        return (NSMethodSignature *)objc_msgSend(_self, methodSignatureSEL, selector);
+                        return ((NSMethodSignature * (*)(id, SEL, SEL))objc_msgSend)(_self, methodSignatureSEL, selector);
                     }
                 }));
                 PSPDFReplaceMethod(objectClass, @selector(methodSignatureForSelector:), methodSignatureSEL, methodSignatureIMP);
@@ -117,7 +117,7 @@ BOOL PSPDFPIsMenuItemSelector(SEL selector) {
                             }
                         }
                     }else {
-                        objc_msgSend(_self, forwardInvocationSEL, invocation);
+                        ((void (*)(id, SEL, NSInvocation *))objc_msgSend)(_self, forwardInvocationSEL, invocation);
                     }
                 }));
                 PSPDFReplaceMethod(objectClass, @selector(forwardInvocation:), forwardInvocationSEL, forwardInvocationIMP);


### PR DESCRIPTION
With the default Xcode build settings these days, this code doesn't even compile unless the casts are in place.

It's also a Good Idea to do these casts. I know this code steers clear of the pitfalls, but just in case someone uses this code to try to learn something, we might as well give them the right idea!
